### PR TITLE
Basic metrics (requests times and count) throught jmx

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,10 +134,16 @@ dependencies {
     runtime group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jVersion
     runtime group: 'org.slf4j', name: 'jul-to-slf4j', version: slf4jVersion
 
+    // Metrics
+    compile group: 'io.dropwizard.metrics', name: 'metrics-core', version: '4.1.0'
+    compile group: 'io.dropwizard.metrics', name: 'metrics-jmx', version: '4.1.0'
+
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
     testCompile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
     testCompile group: 'com.saucelabs', name:'sauce_junit', version: '2.1.24'
+    testCompile group: 'org.powermock', name: 'powermock-api-mockito', version: '1.6.6'
+    testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: '1.6.6'
 
     testCompile group: 'org.seleniumhq.selenium', name:'selenium-java', version: '3.14.0'
     testCompile group: 'com.saucelabs', name:'saucerest', version: '1.0.39'

--- a/src/main/java/io/divolte/server/MetricsHandler.java
+++ b/src/main/java/io/divolte/server/MetricsHandler.java
@@ -1,0 +1,80 @@
+package io.divolte.server;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.jmx.JmxReporter;
+import io.undertow.server.ExchangeCompletionListener;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+@ParametersAreNonnullByDefault
+public class MetricsHandler implements HttpHandler {
+
+    private static final Pattern IGNORE_PATHS = Pattern.compile("^/(ping|static|.*\\.js|.*\\.css).*");
+    private final Timer timer2xx;
+    private final Timer timer3xx;
+    private final Timer timer4xx;
+    private final Timer timer5xx;
+    private final HttpHandler next;
+
+    MetricsHandler(HttpHandler next, MetricRegistry registry) {
+        timer2xx = registry.timer(name(this.getClass(), "requests.2xx"));
+        timer3xx = registry.timer(name(this.getClass(), "requests.3xx"));
+        timer4xx = registry.timer(name(this.getClass(), "requests.4xx"));
+        timer5xx = registry.timer(name(this.getClass(), "requests.5xx"));
+        this.next = next;
+
+        JmxReporter
+            .forRegistry(registry)
+            .inDomain("io.divolte.server")
+            .build()
+            .start();
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange) throws Exception {
+        boolean shouldReportMetric =
+            !(IGNORE_PATHS.matcher(exchange.getRequestPath()).matches() || exchange.isComplete());
+
+        if (shouldReportMetric) {
+            final long start = System.currentTimeMillis();
+            exchange.addExchangeCompleteListener((innerExchange, next) -> exchangeEvent(innerExchange, next, start));
+        }
+
+        next.handleRequest(exchange);
+    }
+
+    void exchangeEvent(HttpServerExchange innerExchange, ExchangeCompletionListener.NextListener
+        nextListener, long start) {
+        long time = System.currentTimeMillis() - start;
+
+        switch (innerExchange.getStatusCode() / 100) {
+            case 2:
+                timer2xx.update(time, TimeUnit.MILLISECONDS);
+                break;
+            case 3:
+                timer3xx.update(time, TimeUnit.MILLISECONDS);
+                break;
+            case 4:
+                timer4xx.update(time, TimeUnit.MILLISECONDS);
+                break;
+            default:
+                timer5xx.update(time, TimeUnit.MILLISECONDS);
+                break;
+        }
+
+        nextListener.proceed();
+    }
+
+    public static MetricsHandler create(HttpHandler next) {
+        MetricRegistry registry = SharedMetricRegistries.getOrCreate("divolte");
+        return new MetricsHandler(next, registry);
+    }
+}

--- a/src/main/java/io/divolte/server/Server.java
+++ b/src/main/java/io/divolte/server/Server.java
@@ -138,11 +138,13 @@ public final class Server implements Runnable {
                 );
 
         shutdownHandler = rootHandler;
+        HttpHandler handler = MetricsHandler.create(
+            vc.configuration().global.server.debugRequests
+                ? new RequestDumpingHandler(rootHandler)
+                : rootHandler);
         undertow = Undertow.builder()
                            .addHttpListener(port, host.orElse(null))
-                           .setHandler(vc.configuration().global.server.debugRequests
-                               ? new RequestDumpingHandler(rootHandler)
-                               : rootHandler)
+                           .setHandler(handler)
                            .build();
     }
 

--- a/src/test/java/io/divolte/server/MetricsHandlerTest.java
+++ b/src/test/java/io/divolte/server/MetricsHandlerTest.java
@@ -1,0 +1,161 @@
+package io.divolte.server;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import io.undertow.server.ExchangeCompletionListener;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(HttpServerExchange.class)
+public class MetricsHandlerTest {
+
+    @Mock
+    private HttpHandler handler;
+    @Mock
+    private MetricRegistry registry;
+    private HttpServerExchange exchange = PowerMockito.mock(HttpServerExchange.class);
+    @Mock
+    private ExchangeCompletionListener.NextListener nextListener;
+    @Mock
+    private Timer timer2xx;
+    @Mock
+    private Timer timer3xx;
+    @Mock
+    private Timer timer4xx;
+    @Mock
+    private Timer timer5xx;
+
+    private MetricsHandler subject;
+
+    @Before
+    public void setup() {
+        when(registry.timer(name(MetricsHandler.class, "requests.time.2xx"))).thenReturn(timer2xx);
+        when(registry.timer(name(MetricsHandler.class, "requests.time.3xx"))).thenReturn(timer3xx);
+        when(registry.timer(name(MetricsHandler.class, "requests.time.4xx"))).thenReturn(timer4xx);
+        when(registry.timer(name(MetricsHandler.class, "requests.time.5xx"))).thenReturn(timer5xx);
+        when(exchange.getStatusCode()).thenReturn(200);
+
+        subject = new MetricsHandler(handler, registry);
+    }
+
+    @Test
+    public void shouldNotSendMetricsForHealthCheckPath() throws Exception {
+        when(exchange.getRequestPath()).thenReturn("/ping");
+
+        subject.handleRequest(exchange);
+
+        verify(exchange, never()).addExchangeCompleteListener(any());
+    }
+
+    @Test
+    public void shouldNotSendMetricsForStaticPath() throws Exception {
+        when(exchange.getRequestPath()).thenReturn("/static/res.png");
+
+        subject.handleRequest(exchange);
+
+        verify(exchange, never()).addExchangeCompleteListener(any());
+    }
+
+    @Test
+    public void shouldNotSendMetricsForStaticJSPath() throws Exception {
+        when(exchange.getRequestPath()).thenReturn("/res.js");
+
+        subject.handleRequest(exchange);
+
+        verify(exchange, never()).addExchangeCompleteListener(any());
+    }
+
+    @Test
+    public void shouldNotSendMetricsForStaticCSSPath() throws Exception {
+        when(exchange.getRequestPath()).thenReturn("/res.css");
+
+        subject.handleRequest(exchange);
+
+        verify(exchange, never()).addExchangeCompleteListener(any());
+    }
+
+    @Test
+    public void shouldNotSendMetricsWhenExchangeIsComplete() throws Exception {
+        when(exchange.getRequestPath()).thenReturn("/path");
+        when(exchange.isComplete()).thenReturn(true);
+
+        subject.handleRequest(exchange);
+
+        verify(exchange, never()).addExchangeCompleteListener(any());
+    }
+
+    @Test
+    public void shouldSendMetricsWhenPathIsAllowedAndExchangeIsNotComplete() throws Exception {
+        when(exchange.getRequestPath()).thenReturn("/path");
+        when(exchange.isComplete()).thenReturn(false);
+
+        subject.handleRequest(exchange);
+
+        verify(exchange).addExchangeCompleteListener(any());
+
+    }
+
+    @Test
+    public void shouldSendMetricsFor2xx() {
+        when(exchange.getStatusCode()).thenReturn(201);
+
+        subject.exchangeEvent(exchange, nextListener, 0L);
+
+        verify(timer2xx).update(anyLong(), any(TimeUnit.class));
+        verify(timer3xx, never()).update(Mockito.anyLong(), any(TimeUnit.class));
+        verify(timer4xx, never()).update(anyLong(), any(TimeUnit.class));
+        verify(timer5xx, never()).update(anyLong(), any(TimeUnit.class));
+    }
+
+    @Test
+    public void shouldSendMetricsFor3xx() {
+        when(exchange.getStatusCode()).thenReturn(302);
+
+        subject.exchangeEvent(exchange, nextListener, 0L);
+
+        verify(timer2xx, never()).update(anyLong(), any(TimeUnit.class));
+        verify(timer3xx).update(anyLong(), any(TimeUnit.class));
+        verify(timer4xx, never()).update(anyLong(), any(TimeUnit.class));
+        verify(timer5xx, never()).update(anyLong(), any(TimeUnit.class));
+    }
+
+    @Test
+    public void shouldSendMetricsFor4xx() {
+        when(exchange.getStatusCode()).thenReturn(404);
+
+        subject.exchangeEvent(exchange, nextListener, 0L);
+
+        verify(timer2xx, never()).update(anyLong(), any(TimeUnit.class));
+        verify(timer3xx, never()).update(anyLong(), any(TimeUnit.class));
+        verify(timer4xx).update(anyLong(), any(TimeUnit.class));
+        verify(timer5xx, never()).update(anyLong(), any(TimeUnit.class));
+    }
+
+    @Test
+    public void shouldSendMetricsFor5xx() {
+        when(exchange.getStatusCode()).thenReturn(500);
+
+        subject.exchangeEvent(exchange, nextListener, 0L);
+
+        verify(timer2xx, never()).update(anyLong(), any(TimeUnit.class));
+        verify(timer3xx, never()).update(anyLong(), any(TimeUnit.class));
+        verify(timer4xx, never()).update(anyLong(), any(TimeUnit.class));
+        verify(timer5xx).update(anyLong(), any(TimeUnit.class));
+    }
+}


### PR DESCRIPTION
## Changelog

- Add metrics for request times and counts, these metrics ignores request for static resources (css, js) and for health check

## Testing

- Start divolte: `./gradlew run`
- Access http://localhost:8290
- Open visualvm and check mbeans of `io.divolte.server.MetricsHandler.requests`
- [x] The counters and percentiles should change for each request
