### PR TITLE
Change dropwizard to statsd lib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,9 +134,8 @@ dependencies {
     runtime group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jVersion
     runtime group: 'org.slf4j', name: 'jul-to-slf4j', version: slf4jVersion
 
-    // Metrics
-    compile group: 'io.dropwizard.metrics', name: 'metrics-core', version: '4.1.0'
-    compile group: 'io.dropwizard.metrics', name: 'metrics-jmx', version: '4.1.0'
+    // StatsD Metrics
+    compile group: 'com.datadoghq', name: 'java-dogstatsd-client', version: '2.8'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'

--- a/src/main/java/io/divolte/server/Server.java
+++ b/src/main/java/io/divolte/server/Server.java
@@ -141,7 +141,8 @@ public final class Server implements Runnable {
         HttpHandler handler = MetricsHandler.create(
             vc.configuration().global.server.debugRequests
                 ? new RequestDumpingHandler(rootHandler)
-                : rootHandler);
+                : rootHandler,
+            vc.configuration().global.statsd);
         undertow = Undertow.builder()
                            .addHttpListener(port, host.orElse(null))
                            .setHandler(handler)

--- a/src/main/java/io/divolte/server/config/GlobalConfiguration.java
+++ b/src/main/java/io/divolte/server/config/GlobalConfiguration.java
@@ -32,6 +32,7 @@ public class GlobalConfiguration {
     @Valid public final KafkaConfiguration kafka;
     @Valid public final GoogleCloudStorageConfiguration gcs;
     @Valid public final GoogleCloudPubSubConfiguration gcps;
+    @Valid public final StatsdConfiguration statsd;
 
     @JsonCreator
     GlobalConfiguration(final ServerConfiguration server,
@@ -39,13 +40,15 @@ public class GlobalConfiguration {
                         final HdfsConfiguration hdfs,
                         final KafkaConfiguration kafka,
                         final GoogleCloudStorageConfiguration gcs,
-                        final GoogleCloudPubSubConfiguration gcps) {
+                        final GoogleCloudPubSubConfiguration gcps,
+                        final StatsdConfiguration statsd) {
         this.server = Objects.requireNonNull(server);
         this.mapper = Objects.requireNonNull(mapper);
         this.hdfs = Objects.requireNonNull(hdfs);
         this.kafka = Objects.requireNonNull(kafka);
         this.gcs = Objects.requireNonNull(gcs);
         this.gcps = Objects.requireNonNull(gcps);
+        this.statsd = Objects.requireNonNull(statsd);
     }
 
     @Override
@@ -57,6 +60,7 @@ public class GlobalConfiguration {
                 .add("gcs", gcs)
                 .add("kafka", kafka)
                 .add("gcps", gcps)
+                .add("statsd", statsd)
                 .toString();
     }
 }

--- a/src/main/java/io/divolte/server/config/StatsdConfiguration.java
+++ b/src/main/java/io/divolte/server/config/StatsdConfiguration.java
@@ -1,0 +1,42 @@
+package io.divolte.server.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+public final class StatsdConfiguration {
+
+    public final boolean enabled;
+    public final String host;
+    public final int port;
+    public final String prefix;
+    public final int bufferSize;
+
+    @JsonCreator
+    public StatsdConfiguration(
+        boolean enabled,
+        String host,
+        int port,
+        String prefix,
+        @JsonProperty("buffer_size") int bufferSize) {
+        this.enabled = enabled;
+        this.host = host;
+        this.port = port;
+        this.prefix = prefix;
+        this.bufferSize = bufferSize;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("enabled", enabled)
+            .add("host", host)
+            .add("port", port)
+            .add("prefix", prefix)
+            .add("bufferSize", bufferSize)
+            .toString();
+    }
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -189,6 +189,21 @@ divolte {
       // The default project-id is picked up from the application environment.
       #project-id =
     }
+
+    statsd {
+      // If true, metrics about request times and counters will be sent to StastD.
+      enabled = false
+
+      // Statds address
+      host = "localhost"
+      port = 8125
+
+      // Prefix to be added to all metrics before sending them
+      prefix = "my.prefix"
+
+      // Buffer size to acumulate messages, so them are sent all togheter
+      buffer_size = 512
+    }
   }
 
   // Sources, sinks and mappings are provided only if the user hasn't


### PR DESCRIPTION
## Changelog

- Remove dropwizard
- Add statsd lib

This was done because dropwizard calculates metrics for all the life time of the application, which wasn't the desired behaviour.

## Testing

- Starts an local statsd
- Start divolte: `./gradlew run`
- Access http://localhost:8290/
- [x] Verify if metrics were sent to statsd

